### PR TITLE
Add deaths data for UK regions.

### DIFF
--- a/src/pipelines/epidemiology/config.yaml
+++ b/src/pipelines/epidemiology/config.yaml
@@ -400,8 +400,6 @@ sources:
   # Authoritative Data sources for GB_UK
   # We make use of the uk_covid19 API provided by PHE, so there is no fetch URL listed here.
   - name: pipelines.epidemiology.gb_authority.Covid19UkL1DataSource
-    # The official data has a bug when going from 01/07/2020 to 02/07/2020 in the cumulative case total.
-    query: (date >= '2020-07-03')
     test:
       # TODO(owahltinez): skip test since it's very flakey
       skip: true
@@ -410,8 +408,6 @@ sources:
       job_group: 'united_kingdom'
 
   - name: pipelines.epidemiology.gb_authority.Covid19UkL2DataSource
-    # The official data has a bug when going from 01/07/2020 to 02/07/2020 in the cumulative case total.
-    query: (date >= '2020-07-03')
     test:
       # TODO(owahltinez): skip test since it's very flakey
       skip: true

--- a/src/pipelines/epidemiology/gb_authority.py
+++ b/src/pipelines/epidemiology/gb_authority.py
@@ -87,6 +87,13 @@ scotland_utla_to_nhs_board_map = {
 }
 
 
+def _fix_bad_total_deceased(data) -> None:
+    # Some areas have bad reporting e.g. UKC on 09/09/2020 has N/A and 0 as
+    # new_deceased and total_deceased, creating an erroneous entry in the data.
+    filter_query = (data.new_deceased.isna()) & (data.total_deceased == 0)
+    data.loc[filter_query, "total_deceased"] = "NaN"
+
+
 class Covid19UkRegionsDataSource(DataSource):
     def parse(self, sources: Dict[str, str], aux: Dict[str, DataFrame], **parse_opts) -> DataFrame:
         # Regions have case data on a "by specimen date" basis.
@@ -118,6 +125,7 @@ class Covid19UkRegionsDataSource(DataSource):
         )
 
         data.date = data.date.apply(lambda x: datetime_isoformat(x, "%Y-%m-%d"))
+        _fix_bad_total_deceased(data)
 
         # Make sure all records have country code and no subregion code
         data["country_code"] = "GB"
@@ -159,6 +167,7 @@ class Covid19UkL2DataSource(DataSource):
         )
 
         data.date = data.date.apply(lambda x: datetime_isoformat(x, "%Y-%m-%d"))
+        _fix_bad_total_deceased(data)
 
         # Make sure all records have country code and no subregion code
         data["country_code"] = "GB"
@@ -199,6 +208,7 @@ class Covid19UkL1DataSource(DataSource):
         )
 
         data.date = data.date.apply(lambda x: datetime_isoformat(x, "%Y-%m-%d"))
+        _fix_bad_total_deceased(data)
 
         # Make sure all records have country code and no subregion code
         data["key"] = "GB"

--- a/src/pipelines/epidemiology/gb_authority.py
+++ b/src/pipelines/epidemiology/gb_authority.py
@@ -92,14 +92,16 @@ class Covid19UkRegionsDataSource(DataSource):
         # Regions have case data on a "by specimen date" basis.
         # This means they don't add up to the counts for nation which are on a
         # "by publish date" basis.
-        cases = {
+        cases_and_deaths = {
             "date": "date",
             "areaCode": "areaCode",
             "newCasesBySpecimenDate": "newCasesBySpecimenDate",
             "cumCasesBySpecimenDate": "cumCasesBySpecimenDate",
+            "newDeaths28DaysByDeathDate": "newDeaths28DaysByDeathDate",
+            "cumDeaths28DaysByDeathDate": "cumDeaths28DaysByDeathDate",
         }
 
-        api = Cov19API(filters=["areaType=region"], structure=cases)
+        api = Cov19API(filters=["areaType=region"], structure=cases_and_deaths)
         regions_json = api.get_json()
         data = DataFrame.from_dict(regions_json["data"])
         data = table_rename(
@@ -108,6 +110,8 @@ class Covid19UkRegionsDataSource(DataSource):
                 "areaCode": "match_string",
                 "newCasesBySpecimenDate": "new_confirmed",
                 "cumCasesBySpecimenDate": "total_confirmed",
+                "newDeaths28DaysByDeathDate": "new_deceased",
+                "cumDeaths28DaysByDeathDate": "total_deceased",
                 "date": "date",
             },
             drop=True,
@@ -125,17 +129,17 @@ class Covid19UkRegionsDataSource(DataSource):
 class Covid19UkL2DataSource(DataSource):
     def parse(self, sources: Dict[str, str], aux: Dict[str, DataFrame], **parse_opts) -> DataFrame:
 
-        cases_and_deaths = {
+        cases_and_deaths_and_tests = {
             "date": "date",
             "areaName": "areaName",
             "newCasesByPublishDate": "newCasesByPublishDate",
             "cumCasesByPublishDate": "cumCasesByPublishDate",
-            "newDeaths28DaysByPublishDate": "newDeaths28DaysByPublishDate",
-            "cumDeaths28DaysByPublishDate": "cumDeaths28DaysByPublishDate",
+            "newDeaths28DaysByDeathDate": "newDeaths28DaysByDeathDate",
+            "cumDeaths28DaysByDeathDate": "cumDeaths28DaysByDeathDate",
             "cumTestsByPublishDate": "cumTestsByPublishDate",
             "newTestsByPublishDate": "newTestsByPublishDate",
         }
-        api = Cov19API(filters=["areaType=nation"], structure=cases_and_deaths)
+        api = Cov19API(filters=["areaType=nation"], structure=cases_and_deaths_and_tests)
         nation_json = api.get_json()
         data = DataFrame.from_dict(nation_json["data"])
 
@@ -145,7 +149,7 @@ class Covid19UkL2DataSource(DataSource):
                 "areaName": "subregion1_name",
                 "newCasesByPublishDate": "new_confirmed",
                 "cumCasesByPublishDate": "total_confirmed",
-                "newDeaths28DaysByPublishDate": "new_deceased",
+                "newDeaths28DaysByDeathDate": "new_deceased",
                 "cumDeaths28DaysByDeathDate": "total_deceased",
                 "newTestsByPublishDate": "new_tested",
                 "cumTestsByPublishDate": "total_tested",
@@ -165,17 +169,17 @@ class Covid19UkL2DataSource(DataSource):
 
 class Covid19UkL1DataSource(DataSource):
     def parse(self, sources: Dict[str, str], aux: Dict[str, DataFrame], **parse_opts) -> DataFrame:
-        cases_and_deaths = {
+        cases_and_deaths_and_tests = {
             "date": "date",
             "areaCode": "areaCode",
             "newCasesByPublishDate": "newCasesByPublishDate",
             "cumCasesByPublishDate": "cumCasesByPublishDate",
-            "newDeaths28DaysByPublishDate": "newDeaths28DaysByPublishDate",
-            "cumDeaths28DaysByPublishDate": "cumDeaths28DaysByPublishDate",
+            "newDeaths28DaysByDeathDate": "newDeaths28DaysByDeathDate",
+            "cumDeaths28DaysByDeathDate": "cumDeaths28DaysByDeathDate",
             "cumTestsByPublishDate": "cumTestsByPublishDate",
             "newTestsByPublishDate": "newTestsByPublishDate",
         }
-        api = Cov19API(filters=["areaType=overview"], structure=cases_and_deaths)
+        api = Cov19API(filters=["areaType=overview"], structure=cases_and_deaths_and_tests)
         data_json = api.get_json()
         data = DataFrame.from_dict(data_json["data"])
 
@@ -185,7 +189,7 @@ class Covid19UkL1DataSource(DataSource):
                 "areaCode": "country_code",
                 "newCasesByPublishDate": "new_confirmed",
                 "cumCasesByPublishDate": "total_confirmed",
-                "newDeaths28DaysByPublishDate": "new_deceased",
+                "newDeaths28DaysByDeathDate": "new_deceased",
                 "cumDeaths28DaysByDeathDate": "total_deceased",
                 "newTestsByPublishDate": "new_tested",
                 "cumTestsByPublishDate": "total_tested",


### PR DESCRIPTION
Fix bugs related to newDeaths in other UK areas.
Switch L1 reporting to DeathsByDeathDate rather than DeathsbyPublishDate.
Use authoritative data for all dates - the previous anomaly has now been fixed.
Replace bad total_deceased 0s with NaN.