### PR TITLE
Add UK L1 hospitalization data source

### DIFF
--- a/src/pipelines/hospitalizations/config.yaml
+++ b/src/pipelines/hospitalizations/config.yaml
@@ -34,7 +34,6 @@ auxiliary:
   knowledge_graph: ./data/knowledge_graph.csv
 
 sources:
-
   # Data sources for AR levels 2 + 3
   - name: pipelines.epidemiology.ar_authority.ArgentinaDataSource
     fetch:
@@ -132,6 +131,16 @@ sources:
     test:
       skip: True
       metadata_query: key.str.match("GB_SCT.*")
+
+  # Data sources for GB level 1
+  - name: pipelines.hospitalizations.gb_authority.UKL1DataSource
+    fetch:
+      - url: "https://api.coronavirus.data.gov.uk/v1/data?filters=areaType=overview&structure=%7B%22areaType%22:%22areaType%22,%22areaName%22:%22areaName%22,%22areaCode%22:%22areaCode%22,%22date%22:%22date%22,%22newAdmissions%22:%22newAdmissions%22,%22cumAdmissions%22:%22cumAdmissions%22%7D&format=csv"
+        opts:
+          # Force CSV file extension
+          ext: csv
+    test:
+      metadata_query: "key == 'GB'"
 
   # Data sources for IE level 1
   - name: pipelines.hospitalizations.xx_opencovid.OpenCovidDataSource

--- a/src/pipelines/hospitalizations/config.yaml
+++ b/src/pipelines/hospitalizations/config.yaml
@@ -134,11 +134,6 @@ sources:
 
   # Data sources for GB level 1
   - name: pipelines.hospitalizations.gb_authority.UKL1DataSource
-    fetch:
-      - url: "https://api.coronavirus.data.gov.uk/v1/data?filters=areaType=overview&structure=%7B%22areaType%22:%22areaType%22,%22areaName%22:%22areaName%22,%22areaCode%22:%22areaCode%22,%22date%22:%22date%22,%22newAdmissions%22:%22newAdmissions%22,%22cumAdmissions%22:%22cumAdmissions%22%7D&format=csv"
-        opts:
-          # Force CSV file extension
-          ext: csv
     test:
       metadata_query: "key == 'GB'"
 

--- a/src/pipelines/hospitalizations/gb_authority.py
+++ b/src/pipelines/hospitalizations/gb_authority.py
@@ -86,12 +86,17 @@ class UKL1DataSource(DataSource):
         data = api.get_dataframe()
 
         # Rename columns and map to expected schema
-        data = data.rename(columns={
-            "newAdmissions": "new_hospitalized",
-            "cumAdmissions": "total_hospitalized",
-            "hospitalCases": "current_hospitalized",
-            "covidOccupiedMVBeds": "current_ventilator"
-        })
+        data = table_rename(
+            data,
+            {
+                "date": "date",
+                "newAdmissions": "new_hospitalized",
+                "cumAdmissions": "total_hospitalized",
+                "hospitalCases": "current_hospitalized",
+                "covidOccupiedMVBeds": "current_ventilator"
+            },
+            drop=True,
+        )
 
         # Add key
         data["key"] = "GB"

--- a/src/pipelines/hospitalizations/gb_authority.py
+++ b/src/pipelines/hospitalizations/gb_authority.py
@@ -56,3 +56,29 @@ class ScotlandDataSource(DataSource):
         )
 
         return hospitalized.merge(intensive_care, how="outer")
+
+
+class UKL1DataSource(DataSource):
+    def parse_dataframes(
+        self, dataframes: Dict[str, DataFrame], aux: Dict[str, DataFrame], **parse_opts
+    ) -> DataFrame:
+
+        # Data is only one source, so we only look at the first item of the list
+        data = dataframes[0]
+
+        # Drop unnecessary columns
+        data = data.drop(columns=["areaType", "areaName", "areaCode"])
+
+        # Rename columns and map to expected schema
+        data = data.rename(columns={
+            "newAdmissions": "new_hospitalized",
+            "cumAdmissions": "total_hospitalized"
+        })
+
+        # Add metadata
+        data["key"] = "GB"
+
+        # Re-order columns
+        data = data[["date", "key", "new_hospitalized", "total_hospitalized"]]
+
+        return data


### PR DESCRIPTION
Small update to add UK L1 hospitalization data source from [official UK authority](https://coronavirus.data.gov.uk/healthcare).

Also related to #232.