### PR TITLE
Add UK L2 hospitalization data

### DIFF
--- a/src/pipelines/hospitalizations/config.yaml
+++ b/src/pipelines/hospitalizations/config.yaml
@@ -192,6 +192,14 @@ sources:
       job_group: all
       deferred: true
 
+  # Data sources for GB level 2
+  - name: pipelines.hospitalizations.gb_authority.UKL2DataSource
+    test:
+      metadata_query: key.str.match("^(GB_ENG|GB_NIR|GB_SCT|GB_WLS)$")
+    automation:
+      job_group: all
+      deferred: true
+
   # Data sources for IE level 1
   - name: pipelines.hospitalizations.xx_opencovid.OpenCovidDataSource
     fetch:

--- a/src/pipelines/hospitalizations/config.yaml
+++ b/src/pipelines/hospitalizations/config.yaml
@@ -195,7 +195,7 @@ sources:
   # Data sources for GB level 2
   - name: pipelines.hospitalizations.gb_authority.UKL2DataSource
     test:
-      metadata_query: key.str.match("^(GB_ENG|GB_NIR|GB_SCT|GB_WLS)$")
+      location_key_match: '^(GB_ENG|GB_NIR|GB_SCT|GB_WLS)$'
     automation:
       job_group: all
       deferred: true


### PR DESCRIPTION
Replace existing Scotland data source with [UK government data source](https://coronavirus.data.gov.uk/healthcare).

Add England, Northern Ireland, and Wales hospitalization data using the same UK government data source.

Addresses #232 .