### PR TITLE
Fixes a possible typo on the Finnish age bins

### DIFF
--- a/src/pipelines/epidemiology/fi_authority.py
+++ b/src/pipelines/epidemiology/fi_authority.py
@@ -53,11 +53,11 @@ class FinlandArcGisDataSource(DataSource):
 
         # Add the age bins
         data["age_bin_00"] = "0-9"
-        data["age_bin_01"] = "10-49"
-        data["age_bin_02"] = "20-59"
+        data["age_bin_01"] = "10-19"
+        data["age_bin_02"] = "20-29"
         data["age_bin_03"] = "30-39"
         data["age_bin_04"] = "40-49"
-        data["age_bin_05"] = "70-59"
+        data["age_bin_05"] = "50-59"
         data["age_bin_06"] = "60-69"
         data["age_bin_07"] = "70-79"
         data["age_bin_08"] = "80-"


### PR DESCRIPTION
----

Currently, the age bins shown in the CVS files for Finland are: 
```
0-9 	10-49 	20-59 	30-39 	40-49 	70-59 	60-69 	70-79 	80-
```
but they seem wrong. Exploring [the query done to obtain the data](https://services7.arcgis.com/nuPvVz1HGGfa0Eh7/arcgis/rest/services/korona_tapauksia_jakauma/FeatureServer/0/query?f=json&where=1%3D1&outFields=OBJECTID,alue,date,tapauksia,miehia,naisia,Ika_0_9,ika_10_19,ika_20_29,ika_30_39,ika_40_49,ika_50_59,ika_60_69,ika_70_79,ika_80_,koodi&returnGeometry=false) it seems this should be:

```
0-9 	10-19 	20-29 	30-39 	40-49 	50-59 	60-69 	70-79 	80-
```